### PR TITLE
Fix API contract in individual assignment (TP1C 2025)

### DIFF
--- a/content/blog/2025-13-03-trabajo-practico-1c-2025-typo.md
+++ b/content/blog/2025-13-03-trabajo-practico-1c-2025-typo.md
@@ -1,0 +1,44 @@
+---
+date: "2025-13-03T17:10:00Z"
+subtitle: Enunciado del 2 Cuatrimestre 2024
+tags:
+- trabajos-practicos
+- 2024-2C
+title: Corrección del contrato del enunciado del TP1C 2025
+---
+
+Detectamos una inconsistencia en la especificación OpenAPI del enunciado original para la creación de cursos (`POST /courses`). Inicialmente, el contrato requería que el `id` fuera un UUID, cuando en realidad **solo los extras evaluaban su uso**. Para alinearlo con los requisitos base, **se corrigió el contrato para que el identificador sea un número entero en la versión estándar**.
+
+### 📌 **¿Qué cambiamos?**
+
+- **Antes**: Se exigía que el `id` fuera un `string` con formato UUID.
+  ```json
+  {
+    "data": {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "title": "Curso de prueba",
+      "description": "Descripción del curso"
+    }
+  }
+  ```
+  
+- **Ahora**: El `id` vuelve a ser un `integer` en la versión base del enunciado.
+  ```json
+  {
+    "data": {
+      "id": 1,
+      "title": "Curso de prueba",
+      "description": "Descripción del curso"
+    }
+  }
+  ```
+
+### 🔍 **¿Qué significa este cambio?**
+- En la versión estándar, el `id` de los cursos será numérico (`integer`).
+- **Solo si se implementa el extra de UUID**, el `id` pasará a ser un `string` con formato UUID.
+- La especificación OpenAPI fue actualizada para reflejar esto correctamente.
+
+⚠️ **¡IMPORTANTE!**  
+Si ya empezaste tu implementación con UUID v4, **no es necesario cambiar nada**, ya que **era parte del extra** y sigue siendo una solución válida. 🚀
+
+Gracias por el feedback y las preguntas, seguimos mejorando el enunciado para mayor claridad. 🚀

--- a/content/tps/2025/1/individual.md
+++ b/content/tps/2025/1/individual.md
@@ -98,12 +98,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                title:
-                    type: string
-                description:
-                    type: string
+              $ref: '#/components/schemas/CreateCourseRequest'
       responses:
         '201':
           description: Course created successfully
@@ -113,14 +108,7 @@ paths:
                 type: object
                 properties:
                   data:
-                    type: object
-                    properties:
-                      id:
-                        type: integer
-                      title:
-                        type: string
-                      description:
-                        type: string
+                    $ref: '#/components/schemas/Course'
         '400':
           description: Bad request error
           content:
@@ -141,14 +129,8 @@ paths:
                   data:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        id:
-                          type: integer
-                        title:
-                          type: string
-                        description:
-                          type: string
+                      $ref: '#/components/schemas/Course'
+
   /courses/{id}:
     get:
       summary: Retrieve a course by ID
@@ -157,9 +139,7 @@ paths:
           name: id
           required: true
           schema:
-            type: string
-            format: uuid
-          example: "123e4567-e89b-12d3-a456-426614174000"
+            type: integer
       responses:
         '200':
           description: Course retrieved successfully
@@ -169,15 +149,7 @@ paths:
                 type: object
                 properties:
                   data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        format: uuid
-                      title:
-                        type: string
-                      description:
-                        type: string
+                    $ref: '#/components/schemas/Course'
         '404':
           description: Course not found
           content:
@@ -198,12 +170,10 @@ paths:
           name: id
           required: true
           schema:
-            type: string
-            format: uuid
-          example: "123e4567-e89b-12d3-a456-426614174000"
+            type: integer
       responses:
         '204':
-              description: Course deleted successfully
+          description: Course deleted successfully
         '404':
           description: Course not found
           content:
@@ -219,6 +189,24 @@ paths:
 
 components:
   schemas:
+    Course:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        description:
+          type: string
+
+    CreateCourseRequest:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+
     ErrorResponse:
       type: object
       properties:
@@ -232,6 +220,7 @@ components:
           type: string
         instance:
           type: string
+
 ```
    - Las respuestas de error deben seguir el RFC 7807 (**). Para este proyecto, por la complejidad, el campo `type` debe ser `about:blank`.
 
@@ -244,7 +233,7 @@ components:
     1. **Uso de Variables de Entorno:**
 
       - **Entorno de desarrollo:** Utilizar variables de entorno para configurar parámetros básicos del servicio, como `HOST`, `PORT`, y `ENVIRONMENT`.
-      - **Persistencia:** Utilizar las variables relacionadas con la conexión a bases de datos (`DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER`, `DATABASE_PASSWORD`) si se emplea una base de datos. Si no aplica, omitir estas variables.
+      - **Persistencia:** Utilizar las variables relacionadas con la conexión a bases de datos (`DATABASE_HOST`, `DATABASE_NAME`, `DATABASE_PORT`, `DATABASE_USER`, `DATABASE_PASSWORD`) si se emplea una base de datos. Si no aplica, omitir estas variables.
 
       - **Aclaraciones:**
         - `ENVIRONMENT`: Define si el entorno es de desarrollo (`development`) o producción (`production`).
@@ -273,9 +262,9 @@ components:
     - Responde con código 400 si la validación falla.
     - Agrega un test para este caso.
 2. **UUID para cursos**:
-    - Asegura que cada curso tenga un UUID.
-    - El servidor debe generar el UUID en la respuesta al momento de crearse un curso (`POST /courses`).
-    - Revisa la especificación de OpenAPI. (*)
+    - Asegura que cada curso tenga un UUID v4.
+    - El servidor debe generar el UUID para un curso al momento de su creación, como respuesta de (`POST /courses`).
+    - El contrato REST debe utilizar el UUID en lugar del ID numérico.
 3. **Usar Middleware para Manejar Errores**:
     - Implementa middleware para el manejo centralizado de errores.
 4. **Mejoras a la Solución**:


### PR DESCRIPTION
This MR updates the API contract in the individual assignment of TP1C 2025 to align the expected `id` format with the original requirements:  

- The **baseline version** now correctly uses an `integer` for `id`.  
- The **UUID format** remains **only as part of the extra implementation**.  
- OpenAPI documentation has been adjusted to reflect this change.  