### PR TITLE
Fairer teacher distribution: adjust layout for odd counts

### DIFF
--- a/layouts/_default/team.html
+++ b/layouts/_default/team.html
@@ -19,13 +19,13 @@
 </head>
 <body>
     <!-- Hero Section -->
-    <div class="relative mb-16">
+    <div class="relative mb">
         {{ partial "sidebar.html" (dict "context" . "disableSidebar" true) }}
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
             <div class="text-center space-y-8">
                 <div>
-                    <div class="inline-flex rounded-full bg-accent-500/10 dark:bg-accent-900/20 p-4 ring-1 ring-accent-500/30 dark:ring-accent-700/30">
-                        <img src="/images/logo.png" alt="Logo" class="w-16 h-16">
+                    <div class="inline-flex w-16 h-16 rounded-full bg-accent-500/10 dark:bg-accent-900/20 p-1 ring-1 ring-accent-500/30 dark:ring-accent-700/30">
+                        <img src="/images/logo.png" alt="Logo" class="w-full h-full object-cover rounded-full dark:invert">
                     </div>
                 </div>
                 <h1 class="text-4xl font-bold text-gray-900 dark:text-white/90 tracking-tight">Equipo Docente</h1>
@@ -34,40 +34,50 @@
     </div>
 
     <!-- Team Grid -->
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-24">
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-            {{ range .Site.Data.team.team }}
-            <!-- Team Member Card -->
-            <div class="group relative aspect-square w-full max-w-xs mx-auto bg-gray-50 dark:bg-gray-900 rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-shadow">
-                <img 
-                    src="{{ .pic }}" 
-                    alt="{{ .name }}"
-                    class="w-full h-full object-cover object-center transition-transform duration-480 group-hover:scale-105"
-                >
-                
-                <!-- Overlay Content -->
-                <div class="absolute inset-0 bg-gradient-to-t from-gray-900/40 via-gray-900/20 to-transparent group-hover:from-dark-950/80 group-hover:via-gray-950/60 group-hover:to-gray-950/30 flex flex-col justify-end p-5 transition-colors">
-                    <!-- Social Icons -->
-                    <div class="flex justify-center space-x-3 mb-3 opacity-0 group-hover:opacity-100 transition-opacity duration-480">
-                        <a href="mailto:{{ .mail }}" class="text-white/80 hover:text-white transition-colors">
-                            <div class="w-12 h-12 rounded-full bg-white/5 backdrop-blur-sm flex items-center justify-center hover:bg-white/10">
-                                <i class="fas fa-envelope text-xl"></i>
-                            </div>
-                        </a>
-                        <a href="https://github.com/{{ .github }}" target="_blank" class="text-white/80 hover:text-white transition-colors">
-                            <div class="w-12 h-12 rounded-full bg-white/5 backdrop-blur-sm flex items-center justify-center hover:bg-white/10">
-                                <i class="fab fa-github text-xl"></i>
-                            </div>
-                        </a>
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pb-24">
+    <div id="team-grid" data-team-grid
+        class="flex flex-wrap justify-center gap-4
+            before:content-[''] before:basis-60 before:h-0 before:shrink-0
+            after:content-['']  after:basis-60  after:h-0  after:shrink-0">
+        {{ range .Site.Data.team.team }}
+        <div class="basis-60 shrink-0">
+            <div class="group relative aspect-square w-full bg-gray-50 dark:bg-gray-900 rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-shadow">
+            <img src="{{ .pic }}" alt="{{ .name }}" class="w-full h-full object-cover object-center transition-transform duration-500 group-hover:scale-105">
+            <div class="absolute inset-0 bg-gradient-to-t from-gray-900/40 via-gray-900/20 to-transparent group-hover:from-gray-950/80 group-hover:via-gray-950/60 group-hover:to-gray-950/30 flex flex-col justify-end p-5 transition-colors">
+                <div class="flex justify-center space-x-3 mb-3 opacity-0 group-hover:opacity-100 transition-opacity duration-500">
+                <a href="mailto:{{ .mail }}" class="text-white/80 hover:text-white">
+                    <div class="w-12 h-12 rounded-full bg-white/5 backdrop-blur-sm flex items-center justify-center hover:bg-white/10">
+                    <i class="fas fa-envelope text-xl"></i>
                     </div>
-                    
-                    <!-- Name -->
-                    <h3 class="text-white font-medium text-m text-center leading-tight">{{ .name }}</h3>
+                </a>
+                <a href="https://github.com/{{ .github }}" target="_blank" class="text-white/80 hover:text-white">
+                    <div class="w-12 h-12 rounded-full bg-white/5 backdrop-blur-sm flex items-center justify-center hover:bg-white/10">
+                    <i class="fab fa-github text-xl"></i>
+                    </div>
+                </a>
                 </div>
+                <h3 class="text-white font-medium text-m text-center leading-tight">{{ .name }}</h3>
             </div>
-            {{ end }}
+            </div>
         </div>
+        {{ end }}
+    </div>
     </div>
 </body>
+<script>
+addEventListener('DOMContentLoaded', () => {
+  const grid = document.querySelector('[data-team-grid]');
+  const [first, ...rest] = [...grid.children];
+
+  const shuffled = rest
+    .map(el => ({ k: crypto.getRandomValues(new Uint32Array(1))[0], el }))
+    .sort((a, b) => a.k - b.k)
+    .map(x => x.el);
+
+  const frag = document.createDocumentFragment();
+  shuffled.forEach(el => frag.appendChild(el));
+  grid.appendChild(frag);
+});
+</script>
 </html>
 {{ end }}


### PR DESCRIPTION
Tweaked layout to ensure a more equitable teacher distribution: for odd numbers, no one is left in the last slot, and ordering is randomized except the first position

cc: @Ignaciocl @recheconea 